### PR TITLE
Prevent module is undefined error from being thrown

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -59,6 +59,6 @@ return scrollIntoView;
 
 
 // CommonJS/Node support.
-if (module !== undefined && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = scrollIntoView;
 }


### PR DESCRIPTION
Have to use `typeof` to check for undefined, or Chrome throws an error;

```
Uncaught ReferenceError: module is not defined
    at polyfill.js:62
```